### PR TITLE
fix: delete tmp files only if they exist

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -100,5 +100,7 @@ for KUSTOMIZATION_FILE in $(find . -type f -name $KUSTOMIZE_CONFIG.yaml -or -nam
   fi
 done
 
+set -x
 [ -f $VALIDATION_ERR ] && rm $VALIDATION_ERR
 [ -f $KUSTOMIZE_BUILD ] && rm $KUSTOMIZE_BUILD
+set +x

--- a/validate.sh
+++ b/validate.sh
@@ -100,5 +100,5 @@ for KUSTOMIZATION_FILE in $(find . -type f -name $KUSTOMIZE_CONFIG.yaml -or -nam
   fi
 done
 
-rm $VALIDATION_ERR
-rm $KUSTOMIZE_BUILD
+[ -f $VALIDATION_ERR ] && rm $VALIDATION_ERR
+[ -f $KUSTOMIZE_BUILD ] && rm $KUSTOMIZE_BUILD

--- a/validate.sh
+++ b/validate.sh
@@ -97,10 +97,8 @@ for KUSTOMIZATION_FILE in $(find . -type f -name $KUSTOMIZE_CONFIG.yaml -or -nam
         print_code "ERROR - kubeconform $KUSTOMIZE_BUILD on command: \n\n\`kubeconform $KUBECONFORM_CONFIG $KUSTOMIZE_BUILD\`" $VALIDATION_ERR
       fi
     fi
+    rm $KUSTOMIZE_BUILD
   fi
 done
 
-set -x
-[ -f $VALIDATION_ERR ] && rm $VALIDATION_ERR
-[ -f $KUSTOMIZE_BUILD ] && rm $KUSTOMIZE_BUILD
-set +x
+rm $VALIDATION_ERR


### PR DESCRIPTION
So the workflow won't break if the tmp file is not existing